### PR TITLE
Added support for query parameters

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -146,7 +146,7 @@
                              navigator.userLanguage || "root").toLowerCase();
 
                         //Override the browser's language using the optional query parameter.
-                        //Written by Sam Reid Chris Malley (PhET Interactive Simulations)
+                        //Written by Chris Malley (PhET Interactive Simulations)
                         if ( typeof localeQueryParameter === 'string' ) {
                             locale = localeQueryParameter;
                         }


### PR DESCRIPTION
Added support for specifying the locale with a query parameter of the form: locale=value.  For example, http://www.website.com/app/?locale=fr would load the French i18n version of the page.  This is to support sites that allow the user to choose between translations of pages (e.g. with a link) without the user having to change browser settings or having the developer deploy multiple variants of the app.
