### PR TITLE
Avoid exception in mixin when target[prop] == null

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -77,12 +77,10 @@
             if (source.hasOwnProperty(prop) && (!target.hasOwnProperty(prop) || force)) {
                 target[prop] = source[prop];
             } else if (typeof source[prop] === 'object') {
-                if (target[prop] != null) {
-                    mixin(target[prop], source[prop], force);
+                if (!target[prop]) {
+                    target[prop] = {};
                 }
-                else {
-                    target[prop] = source[prop];
-                }
+                mixin(target[prop], source[prop], force);
             }
         }
     }


### PR DESCRIPTION
When target[prop] is null then source[prop] should be assigned directly without calling mixin again. It would cause an exception because null.hasOwnProperty is undefined, of course.
