### PR TITLE
Setup a package.json compatible with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,19 @@
 {
-    "volo": {
-        "url": "https://raw.github.com/requirejs/i18n/{version}/i18n.js"
-    }
+  "volo": {
+    "url": "https://raw.github.com/requirejs/i18n/{version}/i18n.js"
+  },
+  "name": "i18n",
+  "description": "An AMD loader plugin for loading internationalization/localization string resources.",
+  "version": "2.0.4",
+  "main": "i18n.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/requirejs/i18n.git"
+  },
+  "author": "jrburke <jrburke@gmail.com>",
+  "license": "BSD or MIT",
+  "bugs": {
+    "url": "https://github.com/requirejs/i18n/issues"
+  },
+  "homepage": "https://github.com/requirejs/i18n"
 }


### PR DESCRIPTION
I'm in the process of moving from browserify to npm for my dependency management and found that you can't use npm to install the i18n plugin.
