### PR TITLE
Custom name for nls directory

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -37,14 +37,6 @@
 (function () {
     'use strict';
 
-    //regexp for reconstructing the master bundle name from parts of the regexp match
-    //nlsRegExp.exec("foo/bar/baz/nls/en-ca/foo") gives:
-    //["foo/bar/baz/nls/en-ca/foo", "foo/bar/baz/nls/", "/", "/", "en-ca", "foo"]
-    //nlsRegExp.exec("foo/bar/baz/nls/foo") gives:
-    //["foo/bar/baz/nls/foo", "foo/bar/baz/nls/", "/", "/", "foo", ""]
-    //so, if match[5] is blank, it means this is the top bundle definition.
-    var nlsRegExp = /(^.*(^|\/)nls(\/|$))([^\/]*)\/?([^\/]*)/;
-
     //Helper function to avoid repeating code. Lots of arguments in the
     //desire to stay functional and support RequireJS contexts without having
     //to know about the RequireJS contexts.
@@ -98,6 +90,18 @@
 
                 if (config.locale) {
                     masterConfig.locale = config.locale;
+                }
+
+                //regexp for reconstructing the master bundle name from parts of the regexp match
+                //nlsRegExp.exec("foo/bar/baz/nls/en-ca/foo") gives:
+                //["foo/bar/baz/nls/en-ca/foo", "foo/bar/baz/nls/", "/", "/", "en-ca", "foo"]
+                //nlsRegExp.exec("foo/bar/baz/nls/foo") gives:
+                //["foo/bar/baz/nls/foo", "foo/bar/baz/nls/", "/", "/", "foo", ""]
+                //so, if match[5] is blank, it means this is the top bundle definition.
+                if(config.i18n && config.i18n.nls) {
+                    var nlsRegExp = new RegExp('(^.*(^|\/)'+config.i18n.nls+'(\/|$))([^\/]*)\/?([^\/]*)');
+                }else{
+                    nlsRegExp = /(^.*(^|\/)nls(\/|$))([^\/]*)\/?([^\/]*)/;
                 }
 
                 var masterName,

--- a/i18n.js
+++ b/i18n.js
@@ -37,6 +37,7 @@
 (function () {
     'use strict';
 
+    debugger
     //Helper function to avoid repeating code. Lots of arguments in the
     //desire to stay functional and support RequireJS contexts without having
     //to know about the RequireJS contexts.
@@ -77,7 +78,17 @@
         }
     }
 
+    //regexp for reconstructing the master bundle name from parts of the regexp match
+    //nlsRegExp.exec("foo/bar/baz/nls/en-ca/foo") gives:
+    //["foo/bar/baz/nls/en-ca/foo", "foo/bar/baz/nls/", "/", "/", "en-ca", "foo"]
+    //nlsRegExp.exec("foo/bar/baz/nls/foo") gives:
+    //["foo/bar/baz/nls/foo", "foo/bar/baz/nls/", "/", "/", "foo", ""]
+    //so, if match[5] is blank, it means this is the top bundle definition.
+    var nlsFolder = (requirejs.s.contexts._.config.i18n && requirejs.s.contexts._.config.i18n.nls) || 'nls';
+    var nlsRegExp = new RegExp('(^.*(^|\/)'+nlsFolder+'(\/|$))([^\/]*)\/?([^\/]*)');
+
     define(['module'], function (module) {
+        debugger
         var masterConfig = module.config ? module.config() : {};
 
         return {
@@ -85,21 +96,13 @@
             /**
              * Called when a dependency needs to be loaded.
              */
+            
             load: function (name, req, onLoad, config) {
                 config = config || {};
 
                 if (config.locale) {
                     masterConfig.locale = config.locale;
                 }
-                
-                //regexp for reconstructing the master bundle name from parts of the regexp match
-                //nlsRegExp.exec("foo/bar/baz/nls/en-ca/foo") gives:
-                //["foo/bar/baz/nls/en-ca/foo", "foo/bar/baz/nls/", "/", "/", "en-ca", "foo"]
-                //nlsRegExp.exec("foo/bar/baz/nls/foo") gives:
-                //["foo/bar/baz/nls/foo", "foo/bar/baz/nls/", "/", "/", "foo", ""]
-                //so, if match[5] is blank, it means this is the top bundle definition.
-                var nlsFolder = (config.i18n && config.i18n.nls) || 'nls';
-                var nlsRegExp = new RegExp('(^.*(^|\/)'+nlsFolder+'(\/|$))([^\/]*)\/?([^\/]*)');
 
                 var masterName,
                     match = nlsRegExp.exec(name),

--- a/i18n.js
+++ b/i18n.js
@@ -91,18 +91,15 @@
                 if (config.locale) {
                     masterConfig.locale = config.locale;
                 }
-
+                
                 //regexp for reconstructing the master bundle name from parts of the regexp match
                 //nlsRegExp.exec("foo/bar/baz/nls/en-ca/foo") gives:
                 //["foo/bar/baz/nls/en-ca/foo", "foo/bar/baz/nls/", "/", "/", "en-ca", "foo"]
                 //nlsRegExp.exec("foo/bar/baz/nls/foo") gives:
                 //["foo/bar/baz/nls/foo", "foo/bar/baz/nls/", "/", "/", "foo", ""]
                 //so, if match[5] is blank, it means this is the top bundle definition.
-                if(config.i18n && config.i18n.nls) {
-                    var nlsRegExp = new RegExp('(^.*(^|\/)'+config.i18n.nls+'(\/|$))([^\/]*)\/?([^\/]*)');
-                }else{
-                    nlsRegExp = /(^.*(^|\/)nls(\/|$))([^\/]*)\/?([^\/]*)/;
-                }
+                var nlsFolder = (config.i18n && config.i18n.nls) || 'nls';
+                var nlsRegExp = new RegExp('(^.*(^|\/)'+nlsFolder+'(\/|$))([^\/]*)\/?([^\/]*)');
 
                 var masterName,
                     match = nlsRegExp.exec(name),


### PR DESCRIPTION
Sometimes (name _nls_ can be busy by project folder) we need to customize name of _nls_ folder.
By setting config param `i18n.nsl` we can specify new name instead of _nls_.

Example

main.js

``` javascript
require.config({
    i18n: {
        nls: 'localization'
    }
});
```

module.js

``` javascript
define(['i18n!localization/strings'], function(strings) {})
```
