### PR TITLE
Fix Chrome/Opera language detection

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -125,7 +125,8 @@
                     if (!locale) {
                         locale = masterConfig.locale =
                             typeof navigator === "undefined" ? "root" :
-                            (navigator.language ||
+                            ((navigator.languages && navigator.languages[0]) ||
+                             navigator.language ||
                              navigator.userLanguage || "root").toLowerCase();
                     }
                     parts = locale.split("-");


### PR DESCRIPTION
Chrome/Opera Invariantly returns the language of the UI through `navigator.language`
See:
https://code.google.com/p/chromium/issues/detail?id=101138
https://code.google.com/p/chromium/issues/detail?id=378246
http://gu.illau.me/posts/follow-up-on-navigator-languages/